### PR TITLE
Fix docs for color option

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Whirly.stop
 The `start` method takes a lot of options, like which spinner to use or an initial status. See further below for the full description of available options.
 
 ```ruby
-Whirly.start spinner: "pong", use_color: false, status: "The Game of Pong" do
+Whirly.start spinner: "pong", color: false, status: "The Game of Pong" do
   sleep 10
 end
 ```

--- a/examples/euruko.rb
+++ b/examples/euruko.rb
@@ -45,7 +45,7 @@ sleep 5
 print "\033c"
 puts Paint["Pong", :underline]
 
-Whirly.start spinner: "pong", use_color: false, status: "Two computers in a game of Pong" do
+Whirly.start spinner: "pong", color: false, status: "Two computers in a game of Pong" do
   sleep 9
 end
 

--- a/examples/single.rb
+++ b/examples/single.rb
@@ -3,4 +3,4 @@ require "paint"
 
 # Call a single spinner from the command-line
 
-Whirly.start(spinner: $*[0], status: $*[2] || $*[0], use_color: false){ sleep(($*[1] || 10).to_i) }
+Whirly.start(spinner: $*[0], status: $*[2] || $*[0], color: false){ sleep(($*[1] || 10).to_i) }


### PR DESCRIPTION
I couldn't get the white spinner by using the documented `use_color: false` option. I had to use the `color: false` option. I updated the docs to reflect what I found.

Test code:

```
require 'whirly'
require 'paint'
Whirly.start(spinner: "dots", use_color: false) { sleep(3) }
```

Expected behavior: white dots spinner
Actual behavior: colored dots spinner

Code after docs change:

```
require 'whirly'
require 'paint'
Whirly.start(spinner: "dots", color: false) { sleep(3) }
```
