### PR TITLE
Stop spinner when block raises an exception

### DIFF
--- a/lib/whirly.rb
+++ b/lib/whirly.rb
@@ -167,8 +167,11 @@ module Whirly
 
     # idiomatic block syntax support
     if block_given?
-      yield
-      Whirly.stop
+      begin
+        yield
+      ensure
+        Whirly.stop
+      end
     end
 
     true


### PR DESCRIPTION
If a block passed to `Whirly.start` raises an exception the spinner is not stopped.

Program to reproduce the issue:
```
require 'whirly'
begin
  Whirly.start status: "working" do
    sleep 1
    raise 'error!'
  end
rescue => e
  puts e.message
end
gets
```

Expected behavior: spinner is shown for 1 second, error! is printed, then the program waits for input on a blank line.

Actual behavior: spinner is shown for 1 second, error! is printed, then the program waits for input with the spinner continuing to show on the right of the cursor.