### PR TITLE
Fix race condition in Whirly.stop

### DIFF
--- a/lib/whirly.rb
+++ b/lib/whirly.rb
@@ -182,7 +182,11 @@ module Whirly
     @enabled = false
     return false unless @options[:stream].tty? || @options[:non_tty]
 
-    @thread.terminate if @thread
+    if @thread
+      @thread.terminate
+      @thread.join
+    end
+
     render(stop_frame || @stop) if stop_frame || @stop
     unrender if @options[:remove_after_stop]
     @options[:stream].puts if @options[:append_newline]


### PR DESCRIPTION
Hiya! I've run across this one a few times using this, there's a race condition in the stop method that can cause unrender to throw an exception.

I see there's two failing tests in this PR, but they are failing on master as well.

- Thread#terminate is not synchronous, it only schedules the thread
  to be killed.
- The thread in the background can on rare occasions unset
  @current_frame after line 1 of Whirly.unrender, causing
  a nil to be passed to Unicode::DisplayWidth.of, and causing
  an exception as a result.
- When we kill the thread, we need to join it to wait for it to
  finish before proceeding, otherwise we risk memory corruption.