### PR TITLE
Bump ruby version to 3.x

### DIFF
--- a/whirly.gemspec
+++ b/whirly.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "unicode-display_width", "~> 1.1"
 
-  gem.required_ruby_version = "~> 2.0"
+  gem.required_ruby_version = "~> 3.0"
 end


### PR DESCRIPTION
Looks like this gem builds and passes tests on ruby 3.x - can we bump the version requirement so we can use this in newer ruby projects?