### PR TITLE
bump ruby version to 4

### DIFF
--- a/whirly.gemspec
+++ b/whirly.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "unicode-display_width", ">= 1.1"
 
-  gem.required_ruby_version = ">= 2.0", "< 4.0"
+  gem.required_ruby_version = ">= 2.0", "~> 4.0"
 end


### PR DESCRIPTION
I've noticed that i can't update my gem to newest ruby because one of their dependency is `whirly` and it required ruby version up to 3.x. 

It blocked me to actualize projects, can you please check that? 


On rubies 4.0.0 tests is successful.

```
Finished in 18.852834s, 2.0156 runs/s, 3.4478 assertions/s.
38 runs, 65 assertions, 0 failures, 0 errors, 0 skips
```